### PR TITLE
Respond to code review comments from Martin B:

### DIFF
--- a/src/LowerPattern.jl
+++ b/src/LowerPattern.jl
@@ -15,11 +15,11 @@ function code(bound_pattern::BoundEqualValueTestPattern, state::BinderState)
     value = bound_pattern.value
     needs_let = (value isa Expr || value isa Symbol) && !isempty(bound_pattern.assigned)
     eval = :($isequal($(bound_pattern.input), $(bound_pattern.value)))
+    block = Expr(:block, bound_pattern.location, eval)
     if needs_let
-        block = Expr(:block, bound_pattern.location, eval)
         Expr(:let, Expr(:block, assignments(bound_pattern.assigned)...), block)
     else
-        eval
+        block
     end
 end
 function code(bound_pattern::BoundRelationalTestPattern, state::BinderState)
@@ -79,7 +79,7 @@ function code(bound_pattern::BoundFetchLengthPattern, state::BinderState)
     :($tempvar = $length($(bound_pattern.input)))
 end
 function code(bound_pattern::BoundFetchBindingPattern, state::BinderState)
-    tempvar = get_temp(bound_pattern.variable)
+    tempvar = get_temp(state, bound_pattern)
     :($(tempvar) = $(bound_pattern.input))
 end
 

--- a/test/rematch.jl
+++ b/test/rematch.jl
@@ -143,6 +143,23 @@ file = Symbol(@__FILE__)
         end
     end
 
+    @testset "field not found" begin
+        let line = 0
+            try
+                line = (@__LINE__) + 2
+                @eval @match Foo(1, 2) begin
+                    Foo(z = 1) => 1
+                end
+                @test false
+            catch ex
+                @test ex isa LoadError
+                e = ex.error
+                @test e isa ErrorException
+                @test e.msg == "$file:$line: Type `Main.Rematch2Tests.Foo` has no field `z`."
+            end
+        end
+    end
+
     @testset "multiple splats" begin
         let line = 0
             try

--- a/test/rematch2.jl
+++ b/test/rematch2.jl
@@ -143,6 +143,23 @@ file = Symbol(@__FILE__)
         end
     end
 
+    @testset "field not found" begin
+        let line = 0
+            try
+                line = (@__LINE__) + 2
+                @eval @match Foo(1, 2) begin
+                    Foo(z = 1) => 1
+                end
+                @test false
+            catch ex
+                @test ex isa LoadError
+                e = ex.error
+                @test e isa ErrorException
+                @test e.msg == "$file:$line: Type `Main.Rematch2Tests.Foo` has no field `z`."
+            end
+        end
+    end
+
     @testset "multiple splats" begin
         let line = 0
             try


### PR DESCRIPTION
Respond to code review comments from @mbravenboer:

- Use `gensym` for temp holding the value for a pattern variable
- Check the named field exists.  If not, error.
- Need location when producing code from the user.
- Add comment explaining why no goto for true branch of test.
- Assert that, when interning a state, it has no label.
- Use `Bool` instead of `Val{true}` for `remove(Pattern, Bool, CodePoint)`
- Use `BoundTrue` instead of `BoundBool` when possible.