### PR TITLE
Infer members to match in positional struct pattern by looking for constructors.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.2.1"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-ReTest = "e0db7c4e-2690-44b9-bad6-7687da720f89"
 
 [compat]
 MacroTools = "0.4, 0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.1"
 
 [deps]
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+ReTest = "e0db7c4e-2690-44b9-bad6-7687da720f89"
 
 [compat]
 MacroTools = "0.4, 0.5"

--- a/src/BindPattern.jl
+++ b/src/BindPattern.jl
@@ -282,7 +282,7 @@ end
 # Infer which fields to match in a positional struct pattern by inspecting the set
 # of constructors.  It would be nice to exclude constructors that have
 # required keyword parameters, but the Julia APIs offer no simple way to determine
-# which keyword parameters have defaults.  That's becasue keyword parameters without
+# which keyword parameters have defaults.  That's because keyword parameters without
 # defaults are just rewritten into keyword parameters with defaults that throw an
 # exception at runtime.  So we exclude functions that have any keyword parameters.
 # If that ends up being problematic, we'll revisit the strategy.
@@ -313,7 +313,7 @@ function infer_fieldnames(type::Type, len::Int, match_positionally::Bool, locati
         # no unique constructor, but the correct number of fields exist; use them
         return members
     elseif len > length(members)
-        error("$(location.file):$(location.line): The type `$type` has $(length(members)) fields but the pattern matches $len fields.")
+        error("$(location.file):$(location.line): The type `$type` has $(length(members)) fields but the pattern expects $len fields.")
     else
         error("$(location.file):$(location.line): Cannot infer which $len of the $(length(members)) fields to match from any positional constructor for `$type`.")
     end

--- a/src/BindPattern.jl
+++ b/src/BindPattern.jl
@@ -364,7 +364,7 @@ function subst_patvars(expr, assigned::ImmutableDict{Symbol, Symbol})
                 if !haskey(new_assigned, patvar)
                     new_assigned = ImmutableDict{Symbol, Symbol}(new_assigned, patvar, tmpvar)
                 end
-                return :($identity($tmpvar))
+                return Expr(:block, tmpvar)
             end
         end
         patvar

--- a/src/BindPattern.jl
+++ b/src/BindPattern.jl
@@ -130,23 +130,13 @@ function bind_pattern!(
             error("$(location.file):$(location.line): Pattern `$source` mixes named and positional arguments.")
         end
 
+        match_positionally = named_count == 0
+
         # bind type at macro expansion time
         pattern0, assigned = bind_pattern!(location, :(::($T)), input, state, assigned)
         bound_type = (pattern0::BoundTypeTestPattern).type
         patterns = BoundPattern[pattern0]
-
-        # TODO: Instead of calling fieldnames, we should call a method that can be
-        # overridden (propertynames?), e.g. by the implementation of `@auto_hash_equals_cached`, so
-        # that macros can add fields that are not visible to pattern-matching.
-        field_names = fieldnames(bound_type)
-
-        match_positionally = named_count == 0
-        if match_positionally
-            fieldcount = length(field_names)
-            if fieldcount != len
-                error("$(location.file):$(location.line): Pattern field count is $len expected $fieldcount.")
-            end
-        end
+        field_names::Tuple = infer_fieldnames(bound_type, len, match_positionally, location)
 
         for i in 1:len
             pat = subpatterns[i]
@@ -282,7 +272,87 @@ function bind_pattern!(
     return (pattern, assigned)
 end
 
-# (interpolation, assigned0) = subst_patvars(interpolation, assigned)
+function push_pattern!(patterns::Vector{BoundPattern}, state::BinderState, pat::BoundFetchPattern)
+    temp = get_temp(state, pat)
+    push!(patterns, pat)
+    temp
+end
+
+#
+# Infer which fields to match in a positional struct pattern by inspecting the set
+# of constructors.  It would be nice to exclude constructors that have
+# required keyword parameters, but the Julia APIs offer no simple way to determine
+# which keyword parameters have defaults.  That's becasue keyword parameters without
+# defaults are just rewritten into keyword parameters with defaults that throw an
+# exception at runtime.  So we exclude functions that have any keyword parameters.
+# If that ends up being problematic, we'll revisit the strategy.
+#
+function infer_fieldnames(type::Type, len::Int, match_positionally::Bool, location::LineNumberNode)
+    members = try
+        fieldnames(type)
+    catch ex
+        error("$(location.file):$(location.line): Could not determine the field names of `$type`.")
+    end
+
+    # If we're matching by keyword, we permit the use of any declared fields.
+    match_positionally || return members
+
+    # Search for constructor methods that have the correct number of parameters,
+    # no keyword parameters, and are not varargs.
+    meths = filter(m -> !m.isva && length(Base.kwarg_decl(m))==0, methods(type))
+    # drop the implicit var"#self#" argument
+    argnames = map(m -> dropfirst(Base.method_argnames(m)), meths)
+    # narrow to arg lists of the correct length where all parameter names correspond to members
+    argnames = unique(filter(l -> length(l) == len && all(n -> n in members, l), argnames))
+
+    if length(argnames) == 1
+        # found a uniquely satisfying order for member names
+        return (argnames[1]...,)
+    elseif len == length(members)
+        # no unique constructor, but the correct number of fields exist; use them
+        return members
+    elseif len > length(members)
+        error("$(location.file):$(location.line): The type `$type` has $(length(members)) fields but the pattern matches $len fields.")
+    else
+        error("$(location.file):$(location.line): Cannot infer which $len of the $(length(members)) fields to match from any positional constructor for `$type`.")
+    end
+end
+dropfirst(a) = a[2:length(a)]
+
+#
+# Shred a `where` clause into its component parts, conjunct by conjunct.  If necessary,
+# we push negation operators down.  This permits us to share the parts of a where clause
+# between different rules.
+#
+function shred_where_clause(
+    guard::Any,
+    inverted::Bool,
+    location::LineNumberNode,
+    state::BinderState,
+    assigned::ImmutableDict{Symbol, Symbol})::BoundPattern
+    if @capture(guard, !g_)
+        return shred_where_clause(g, !inverted, location, state, assigned)
+    elseif @capture(guard, g1_ && g2_) || @capture(guard, g1_ || g2_)
+        left = shred_where_clause(g1, inverted, location, state, assigned)
+        right = shred_where_clause(g2, inverted, location, state, assigned)
+        # DeMorgan's law:
+        #     `!(a && b)` => `!a || !b`
+        #     `!(a || b)` => `!a && !b`
+        result_type = (inverted == (guard.head == :&&)) ? BoundOrPattern : BoundAndPattern
+        return result_type(location, guard, BoundPattern[left, right])
+    else
+        (guard0, assigned0) = subst_patvars(guard, assigned)
+        fetch = BoundFetchExpressionPattern(location, guard, guard0, assigned0)
+        temp = get_temp(state, fetch)
+        test = BoundWhereTestPattern(location, guard, temp, inverted)
+        return BoundAndPattern(location, guard, BoundPattern[fetch, test])
+    end
+end
+
+#
+# Replace each pattern variable reference with the temporary variable holding the
+# value that corresponds to that pattern variable.
+#
 function subst_patvars(expr, assigned::ImmutableDict{Symbol, Symbol})
     new_assigned = ImmutableDict{Symbol, Symbol}()
     # postwalk(f, x) = walk(x, x -> postwalk(f, x), f)

--- a/src/BindPattern.jl
+++ b/src/BindPattern.jl
@@ -299,7 +299,8 @@ function infer_fieldnames(type::Type, len::Int, match_positionally::Bool, locati
 
     # Search for constructor methods that have the correct number of parameters,
     # no keyword parameters, and are not varargs.
-    meths = filter(m -> !m.isva && length(Base.kwarg_decl(m))==0, methods(type))
+    meths = Method[methods(type)...]
+    meths = filter(m -> !m.isva && length(Base.kwarg_decl(m))==0, meths)
     # drop the implicit var"#self#" argument
     argnames = map(m -> dropfirst(Base.method_argnames(m)), meths)
     # narrow to arg lists of the correct length where all parameter names correspond to members

--- a/test/rematch.jl
+++ b/test/rematch.jl
@@ -159,7 +159,7 @@ file = Symbol(@__FILE__)
                 @test ex isa LoadError
                 e = ex.error
                 @test e isa ErrorException
-                @test e.msg == "$file:$line: The type `$Foo` has 2 fields but the pattern matches 3 fields."
+                @test e.msg == "$file:$line: The type `$Foo` has 2 fields but the pattern expects 3 fields."
             end
         end
     end

--- a/test/rematch.jl
+++ b/test/rematch.jl
@@ -159,7 +159,7 @@ file = Symbol(@__FILE__)
                 @test ex isa LoadError
                 e = ex.error
                 @test e isa ErrorException
-                @test e.msg == "$file:$line: Pattern field count is 3 expected 2."
+                @test e.msg == "$file:$line: The type `$Foo` has 2 fields but the pattern matches 3 fields."
             end
         end
     end
@@ -176,7 +176,7 @@ file = Symbol(@__FILE__)
                 @test ex isa LoadError
                 e = ex.error
                 @test e isa ErrorException
-                @test e.msg == "$file:$line: Type `Main.Rematch2Tests.Foo` has no field `z`."
+                @test e.msg == "$file:$line: Type `$Foo` has no field `z`."
             end
         end
     end

--- a/test/rematch2.jl
+++ b/test/rematch2.jl
@@ -466,6 +466,22 @@ end
         end
     end
 
+    @testset "assignment to pattern variables not permitted" begin
+        let line = 0
+            try
+                line = (@__LINE__) + 2
+                @eval @match2 1 begin
+                    x => (x = 4)
+                end
+                @test false
+            catch e
+                @test e isa ErrorException
+                @test startswith(e.msg, "syntax: invalid assignment location")
+                @test endswith(e.msg, "around $file:$line")
+            end
+        end
+    end
+
 end
 
 # Tests inherited from Rematch below

--- a/test/rematch2.jl
+++ b/test/rematch2.jl
@@ -332,7 +332,7 @@ end
                 @test ex isa LoadError
                 e = ex.error
                 @test e isa ErrorException
-                @test e.msg == "$file:$line: The type `$Foo` has 2 fields but the pattern matches 3 fields."
+                @test e.msg == "$file:$line: The type `$Foo` has 2 fields but the pattern expects 3 fields."
             end
         end
     end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -80,3 +80,18 @@ struct App <: Term
     f::Term
     v::Term
 end
+
+struct T207a
+    x; y; z
+    T207a(x, y) = new(x, y, x)
+end
+
+struct T207b
+    x; y; z
+    T207b(x, y; z = x) = new(x, y, z)
+end
+
+struct T207c
+    x; y; z
+end
+T207c(x, y) = T207c(x, y, x)


### PR DESCRIPTION
Fixes #18

Note: this PR is built on top of PR https://github.com/gafter/Rematch2.jl/pull/23. After that PR is merged this should be retargeted to the main branch. There is only one commit unique to this PR that needs to be reviewed.